### PR TITLE
Use libbfd multiarch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     - librsvg2-bin
     - libfuse-dev
     - desktop-file-utils
-    - binutils-dev
+    - binutils-multiarch-dev
     - libxml2-dev
     - libcurl4-openssl-dev
     - libboost-program-options-dev

--- a/thirdparty/FindBfd.cmake
+++ b/thirdparty/FindBfd.cmake
@@ -34,7 +34,7 @@ find_path(LIBBFD_INCLUDE_DIRS
 # Ugly, yes ugly...
 find_library(LIBBFD_BFD_LIBRARY
         NAMES
-        bfd
+        bfd-multiarch
         PATHS
         /usr/lib
         /usr/lib64


### PR DESCRIPTION
Bind to the multiarch build of libbfd to enable proper detection of a wider range of architectures.